### PR TITLE
Implement grampanchayat system for maharashtra

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,9 +1,9 @@
+/* Import Google Fonts for Government Portal */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+Devanagari:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Import Google Fonts for Government Portal */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+Devanagari:wght@400;500;600;700&display=swap');
 
 :root {
   --background: #f9fafb;


### PR DESCRIPTION
Move `@import` statement for Google Fonts to the top of `globals.css`.

This fixes a build error where `@import` rules were not preceding other CSS rules, as required by CSS syntax.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-fca6b90a-a411-461b-a940-aee99e6f707e) · [Cursor](https://cursor.com/background-agent?bcId=bc-fca6b90a-a411-461b-a940-aee99e6f707e)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)